### PR TITLE
Corregir workflow deployment sin baseurl

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll site to GitHub Pages (Test Environment)
+name: Deploy Jekyll site to GitHub Pages
 
 on:
   push:
@@ -37,11 +37,11 @@ jobs:
         id: pages
         uses: actions/configure-pages@v4
 
-      - name: Build with Jekyll (using test config)
+      - name: Build with Jekyll
         run: |
           cd sitio-web
-          # Use _config_test.yml for manureta testing environment  
-          bundle exec jekyll build --config _config.yml,_config_test.yml --destination ./_site
+          # Use standard config for production deployment
+          bundle exec jekyll build --destination ./_site
         env:
           JEKYLL_ENV: production
 


### PR DESCRIPTION
## Problema identificado
El workflow estaba usando `_config_test.yml` con `baseurl: "/encuentro-2025"` pero osm-ar se despliega en dominio propio sin subdirectorio, causando rutas rotas.

## Solución
- ✅ Remover `_config_test.yml` del build de producción  
- ✅ Usar configuración Jekyll estándar para deployment directo
- ✅ Evitar problema de rutas absolutas con baseurl incorrecto

## Resultado esperado
- Deployment exitoso en osm-ar.github.io
- Rutas funcionando correctamente sin prefijo de subdirectorio

🤖 Generated with [Claude Code](https://claude.ai/code)